### PR TITLE
Fix glb mime type detection

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -52,7 +52,8 @@ class Application extends App {
 		$mimeTypeDetector->getAllMappings();
 		$mimeTypeDetector->registerType('dae', 'model/vnd.collada+xml', null);
 		$mimeTypeDetector->registerType('fbx', 'model/fbx-dummy', null);
-		$mimeTypeDetector->registerType('gltf', 'model/gltf-binary', 'model/gltf+json');
+		$mimeTypeDetector->registerType('glb', 'model/gltf-binary', null);
+		$mimeTypeDetector->registerType('gltf', 'model/gltf+json', null);
 		$mimeTypeDetector->registerType('obj', 'model/obj-dummy', null);
 		$mimeTypeDetector->registerType('stl', 'application/sla', null);
 		// There is no standard type for gcode, therefore we use cura's mimetype for gcode


### PR DESCRIPTION
Hi @v1r0x, thank you for the quick release of 0.5.0.

I noticed that .glb files don't open the preview. If I rename them to .gltf and refresh Nextcloud, they open properly. But .glb initiates a download.

Based on [Nextcloud source](https://github.com/nextcloud/server/blob/e167d7f44ce9adb43b021e83b8782d3413081e45/lib/private/Files/Type/Detection.php#L94-L110) I believe it is caused by an error in calling `registerType` which this PR fixes.

Tested with a private Nextcloud installation. I needed to empty the filecache for existing .glb files to update the mimetype, but otherwise the fix works.