### PR TITLE
Support ifc format

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -60,6 +60,7 @@ class Application extends App {
 		$mimeTypeDetector->registerType('stl', 'application/sla', null);
 		// There is no standard type for gcode, therefore we use cura's mimetype for gcode
 		$mimeTypeDetector->registerType('gcode', 'text/x-gcode', null);
+		$mimeTypeDetector->registerType('ifc', 'application/x-step', null);
 
 		// Watch Viewer load event
 		$eventDispatcher->addServiceListener(LoadViewer::class, LoadFiles3dScript::class);

--- a/lib/Listener/CSPListener.php
+++ b/lib/Listener/CSPListener.php
@@ -39,6 +39,7 @@ class CSPListener implements IEventListener {
 
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedConnectDomain('data:');
+		$csp->allowEvalScript(true); // required for IFC
 
 		$event->addPolicy($csp);
 	}

--- a/lib/Migration/AddMimetypeToFilecache.php
+++ b/lib/Migration/AddMimetypeToFilecache.php
@@ -29,6 +29,7 @@ class AddMimetypeToFilecache implements IRepairStep {
 			'stl' => 'application/sla',
 			'ply' => 'model/vnd.ply',
 			'gcode' => 'text/x-gcode',
+			'ifc' => 'application/x-step',
 		];
 		foreach($mimes as $ext => $mime) {
 			$mimetypeId = $this->mimeTypeLoader->getId($mime);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "files_3d",
       "version": "0.6.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "lil-gui": "^0.16.0",
-        "three": "^0.138",
+        "three": "^0.139.2",
         "vue": "^2.6.14"
       },
       "devDependencies": {
@@ -8443,9 +8442,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.138.3",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.138.3.tgz",
-      "integrity": "sha512-4t1cKC8gimNyJChJbaklg8W/qj3PpsLJUIFm5LIuAy/hVxxNm1ru2FGTSfbTSsuHmC/7ipsyuGKqrSAKLNtkzg=="
+      "version": "0.139.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.139.2.tgz",
+      "integrity": "sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -15386,9 +15385,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.138.3",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.138.3.tgz",
-      "integrity": "sha512-4t1cKC8gimNyJChJbaklg8W/qj3PpsLJUIFm5LIuAy/hVxxNm1ru2FGTSfbTSsuHmC/7ipsyuGKqrSAKLNtkzg=="
+      "version": "0.139.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.139.2.tgz",
+      "integrity": "sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/v1r0x/files_3d#readme",
   "dependencies": {
     "lil-gui": "^0.16.0",
-    "three": "^0.138",
+    "three": "^0.139.2",
     "vue": "^2.6.14"
   },
   "devDependencies": {

--- a/src/components/Files3d.vue
+++ b/src/components/Files3d.vue
@@ -52,7 +52,8 @@ import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader.js'
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js'
 import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader.js'
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js'
-import { VertexNormalsHelper } from 'three/examples/jsm/helpers/VertexNormalsHelper.js';
+import { IFCLoader } from 'three/examples/jsm/loaders/IFCLoader.js'
+import { VertexNormalsHelper } from 'three/examples/jsm/helpers/VertexNormalsHelper.js'
 import { GUI } from 'lil-gui'
 
 export default {
@@ -230,6 +231,9 @@ export default {
 			case 'text/x-gcode':
 				this.showGcode(this.davPath)
 				break
+			case 'application/x-step':
+				this.showIfc(this.davPath)
+				break
 			}
 		},
 		showCollada(path) {
@@ -355,6 +359,17 @@ export default {
 			event => { // onProgress
 			},
 			event => { // onError
+			})
+		},
+		showIfc(path) {
+			const loader = new IFCLoader()
+			loader.load(path, data => {
+				const gltf = data
+				const object = gltf.scene
+				this.addModelToScene(object, gltf.animations)
+			}, event => { // onProgress
+			}, error => { // onError
+				console.error(error)
 			})
 		},
 		addModelToScene(model, animations) {

--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,7 @@ if (OCA.Viewer) {
 			// PLY has no mime
 			'model/vnd.ply',
 			'text/x-gcode',
+			'application/x-step',
 		],
 
 		// your vue component view


### PR DESCRIPTION
- [ ] requires https://github.com/v1r0x/files_3d/pull/59 to be merged first to get latest three JS

- [ ] loader is not working due to unsafe-eval:
<img width="476" alt="image" src="https://user-images.githubusercontent.com/277525/161255059-d22603af-e3d7-4b65-9ed1-df840038bc89.png">


I'm wondering if we should allow to disable loaders in the configuration, this way if someone is not using formats like IFC they could disable it and bypass the security concerns.